### PR TITLE
ci: enforce repository integrity checks

### DIFF
--- a/.github/workflows/repository-tools.yml
+++ b/.github/workflows/repository-tools.yml
@@ -1,25 +1,8 @@
 name: Test Repository Tools
 
 on:
-  push:
-    branches:
-      - main
-      - master
-    paths:
-      - ".github/workflows/examples.yml"
-      - ".github/workflows/repository-tools.yml"
-      - "scripts/**"
-      - "releases/*.py"
-      - "tests/**"
-      - "config/**"
-  pull_request:
-    paths:
-      - ".github/workflows/examples.yml"
-      - ".github/workflows/repository-tools.yml"
-      - "scripts/**"
-      - "releases/*.py"
-      - "tests/**"
-      - "config/**"
+  push: {}
+  pull_request: {}
   workflow_dispatch:
 
 permissions:
@@ -36,5 +19,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Show Python version
         run: python3 --version
+      - name: Verify immutable firmware artifacts
+        run: python3 scripts/verify_firmware_artifacts.py --repo . --manifest firmware/artifacts.json --index
       - name: Run repository tool tests
         run: python3 -m unittest discover -s tests -p "test_*.py" -v

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -8,7 +8,7 @@ The `Build Examples` workflow first classifies changes, runs the Markdown gate i
 - Arduino sketches are discovered from `.ino` files under `examples/arduino/`, excluding `examples/arduino/libraries/**`.
 - Factory/recovery firmware under `firmware/` is documented for flashing, but is not rebuilt by CI.
 
-Markdown is documentation-only even inside an example or bundled library. Direct example source selects its owning entry; `config/`, ESP-IDF shared inputs, bundled Arduino-library source, workflow/discovery/packaging inputs select the relevant full surface. Unknown non-document inputs conservatively select both surfaces. `firmware/` changes are reported as a separate maintenance surface and never enter an example matrix; binary or archive changes additionally require release review.
+Markdown is documentation-only even inside an example or bundled library. Direct example source selects its owning entry; `config/`, ESP-IDF shared inputs, bundled Arduino-library source, workflow/discovery/packaging inputs select the relevant full surface. Unknown non-document inputs conservatively select both surfaces. `firmware/` changes are reported as a separate maintenance surface and never enter an example matrix; `.bin` files and archives explicitly classified as delivery artifacts additionally require release review.
 
 On pull requests, the route job runs the repository-local Markdown audit against the merge base at the exact pull-request head. Ordinary branch pushes use the non-zero `before` commit as the changed-scope base; tags, manual runs, and all-zero `before` pushes run only the complete inventory. When routing reports `docs_only=true`, every changed-scope command also asserts `--expect-docs-only`. Every event runs the complete tracked Markdown inventory. Any audit failure fails `route`, and therefore `ci-status`.
 
@@ -25,6 +25,8 @@ Matrix configured at the time of this update:
 The workflow and discovery script together are the source of truth for version pins. Update this snapshot whenever that current CI configuration changes.
 
 The largest matrix is 33 builds (10 ESP-IDF examples × 2 versions plus 13 Arduino sketches). Each successful matrix build uploads a flashable firmware artifact. Download the artifact zip from the workflow run, extract it, then run `flash.sh` or `flash.bat` with the board serial port.
+
+The lightweight repository-tools workflow also verifies the immutable checked-in firmware manifest with `python3 scripts/verify_firmware_artifacts.py --repo . --manifest firmware/artifacts.json --index`. That verification is read-only and remains separate from example matrices. A binary-only factory-firmware change requires release review and does not select example builds. Changes to the manifest, verifier, discovery/routing policy, or repository-tools workflow are global CI inputs and intentionally select the complete example matrix.
 
 For artifact packaging and download details, see [../releases/README.md](../releases/README.md).
 

--- a/docs/CI_CN.md
+++ b/docs/CI_CN.md
@@ -8,7 +8,7 @@
 - Arduino sketches 从 `examples/arduino/` 下的 `.ino` 文件发现，但排除 `examples/arduino/libraries/**`。
 - `firmware/` 下的工厂/恢复固件仅用于烧录和恢复说明，不由 CI 重新构建。
 
-Markdown 即使位于示例或随附库中也只算文档。直接示例源码只选择所属入口；`config/`、ESP-IDF 共享输入、随附 Arduino 库源码以及工作流/发现/打包输入会选择相应完整表面。未知非文档输入会保守选择两个表面；`firmware/` 改动会作为独立维护范围报告且绝不进入示例矩阵，其中二进制或归档改动还需要发布审查。
+Markdown 即使位于示例或随附库中也只算文档。直接示例源码只选择所属入口；`config/`、ESP-IDF 共享输入、随附 Arduino 库源码以及工作流/发现/打包输入会选择相应完整表面。未知非文档输入会保守选择两个表面；`firmware/` 改动会作为独立维护范围报告且绝不进入示例矩阵，其中 `.bin` 文件和在 manifest 中明确分类为交付产物的归档还需要发布审查。
 
 在 PR 中，route job 会在精确的 PR head 上，以 merge base 运行仓库内的 Markdown audit。普通分支 push 使用非全零的 `before` commit 作为 changed-scope base；tag、手动运行及 `before` 全零的 push 只运行完整清单。若路由结果为 `docs_only=true`，每个 changed-scope 命令还会断言 `--expect-docs-only`。每个事件都会运行完整的已跟踪 Markdown 清单。任一 audit 失败都会令 `route` 和 `ci-status` 失败。
 
@@ -25,6 +25,8 @@ Markdown 契约将首页定义为多产品 hub：本地化页头使用中性的�
 版本固定值以工作流与示例发现脚本共同为准；当前 CI 配置更新时，请同步更新这里的快照。
 
 完整矩阵最多 33 个构建（10 个 ESP-IDF 示例 × 2 个版本，加 13 个 Arduino sketches）。每个成功构建都会上传可烧录 firmware artifact。下载 workflow run 中的 artifact zip，解压后使用板卡串口运行 `flash.sh` 或 `flash.bat`。
+
+轻量 repository-tools 工作流还会使用 `python3 scripts/verify_firmware_artifacts.py --repo . --manifest firmware/artifacts.json --index` 校验不可变的已检入固件 manifest。该校验为只读，且与示例矩阵分离。仅变更工厂固件二进制文件时需要发布审查，但不会选择示例构建；变更 manifest、校验器、发现/路由策略或 repository-tools 工作流属于全局 CI 输入，会有意选择完整示例矩阵。
 
 Artifact 打包和下载说明见 [../releases/README_CN.md](../releases/README_CN.md)。
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -17,4 +17,6 @@ Small local components remain only where they are board-example glue:
 
 Arduino examples use bundled libraries from `examples/arduino/libraries` so CI and customer builds use the same known library set.
 
+The exact component pins in the manifests are the current repository compatibility set for the ESP-IDF v5.5 and v6 CI lines. The BSP/custom-I/O/RTC pins are the registry releases selected during maintenance. ESP-Brookesia `0.4.2` is intentionally retained instead of `0.5.0` until both IDF lines and board hardware behavior have been validated; revisit these pins after that validation. This records the current maintenance policy and does not claim hardware qualification by this change.
+
 When a local reusable driver becomes available as a maintained Waveshare or Espressif component, prefer migrating the example manifest to the managed component and keep local code only for board-specific glue.

--- a/docs/components_CN.md
+++ b/docs/components_CN.md
@@ -5,3 +5,5 @@
 ESP-IDF 示例优先使用托管组件：`waveshare/esp32_s3_touch_lcd_4` 提供板级 BSP，`waveshare/pcf85063a` 提供 RTC，`waveshare/custom_io_expander_ch32v003` 提供辅助控制器，`lvgl/lvgl` 按示例选择主版本，`espressif/esp-brookesia` 用于 Brookesia 示例。
 
 本地 `components/can` 和 `components/apps` 仅保留板级示例胶水代码。Arduino 示例使用 `examples/arduino/libraries` 中的随附库，以使 CI 与用户构建使用相同版本。
+
+manifest 中的精确组件固定值是当前仓库面向 ESP-IDF v5.5 和 v6 CI 的兼容组合。BSP/自定义 I/O/RTC 的固定值是维护时选定的 registry 发布版本。ESP-Brookesia `0.4.2` 有意保留而不升级至 `0.5.0`，直到两个 IDF 版本和板级硬件行为均已验证；完成该验证后再重新评估这些固定值。本说明记录当前维护策略，并不声称本次变更完成了硬件认证。

--- a/docs/firmware.md
+++ b/docs/firmware.md
@@ -4,6 +4,8 @@
 
 `firmware/` contains factory/recovery binary artifacts for user flashing and recovery flows. These binaries are released files from Waveshare; they are not source projects and are not rebuilt by CI.
 
+The immutable factory artifact inventory is [`firmware/artifacts.json`](../firmware/artifacts.json). Verify the working-tree files read-only from the repository root with `python3 scripts/verify_firmware_artifacts.py --repo . --manifest firmware/artifacts.json`; CI adds `--index` to verify the exact checked-in blobs. The manifest records only the repository-relative artifact path, SHA-256 digest, byte size, and artifact kind. It does not make factory firmware part of example matrices or infer an archive's role from its filename suffix alone; an archive becomes a delivery artifact only when first-party evidence explicitly classifies it in the manifest.
+
 Source-maintained firmware should live under `examples/esp-idf/` or another documented source directory with its own `CMakeLists.txt`, component manifest, and validation path.
 
 CI build outputs are packaged by `releases/package_firmware.py` and uploaded as workflow artifacts. Before flashing artifacts to ESP32-S3-LCD-4, prefer display/peripheral examples or firmware paths that tolerate missing GT911 touch input. Each generated zip contains `manifest.json`, `flash.sh`, `flash.bat`, `flash_args.txt`, and the binaries needed by esptool.

--- a/docs/firmware_CN.md
+++ b/docs/firmware_CN.md
@@ -4,6 +4,8 @@
 
 `firmware/` 保存面向用户烧录和恢复流程的工厂/恢复二进制文件。这些文件是 Waveshare 发布产物，不是源码工程，也不会由 CI 重新构建。
 
+不可变工厂固件清单位于 [`firmware/artifacts.json`](../firmware/artifacts.json)。请在仓库根目录以只读方式运行 `python3 scripts/verify_firmware_artifacts.py --repo . --manifest firmware/artifacts.json` 校验工作树文件；CI 会增加 `--index` 以校验精确的已检入 blob。该 manifest 仅记录仓库相对路径、SHA-256 摘要、字节大小和产物类型；它不会把工厂固件加入示例矩阵，也不会仅凭文件名后缀推断归档用途。只有在第一方证据于 manifest 中明确分类后，归档才视为交付产物。
+
 从源码维护的固件应放在 `examples/esp-idf/`，或另一个有明确说明的源码目录，并包含自己的 `CMakeLists.txt`、组件 manifest 和验证路径。
 
 CI 构建输出由 `releases/package_firmware.py` 打包并上传为 workflow artifacts。烧录到 ESP32-S3-LCD-4 前，请优先选择显示/外设示例，或确认固件路径能够容忍缺少 GT911 触摸输入。每个 zip 包含 `manifest.json`、`flash.sh`、`flash.bat`、`flash_args.txt` 以及 esptool 烧录所需的二进制文件。

--- a/firmware/artifacts.json
+++ b/firmware/artifacts.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "artifacts": [
+    {
+      "path": "firmware/ESP32-S3-Touch-LCD-4-V4.0-FactoryOnly-251122.bin",
+      "kind": "firmware",
+      "sha256": "5db7ee79f1063465d8114cea3a4675c8c87bdf303c2a3edaf6a55414c8634706",
+      "size": 2913440
+    }
+  ]
+}

--- a/scripts/discover_examples.py
+++ b/scripts/discover_examples.py
@@ -14,8 +14,11 @@ DEFAULT_ARDUINO_CORE = "3.3.11"
 COMMON_GLOBAL_SELECTORS = frozenset(
     {
         ".github/workflows/examples.yml",
+        ".github/workflows/repository-tools.yml",
         "releases/package_firmware.py",
         "scripts/discover_examples.py",
+        "scripts/verify_firmware_artifacts.py",
+        "firmware/artifacts.json",
     }
 )
 

--- a/scripts/route_ci.py
+++ b/scripts/route_ci.py
@@ -8,7 +8,7 @@ import json
 import subprocess
 import sys
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import discover_examples
 
@@ -19,15 +19,18 @@ DOCUMENTATION_ASSET_PATHS = frozenset({"assets/ESP32-S3-LCD-4-family.jpg"})
 GLOBAL_PATHS = frozenset(
     {
         ".github/workflows/examples.yml",
+        ".github/workflows/repository-tools.yml",
         "scripts/route_ci.py",
         "scripts/discover_examples.py",
+        "scripts/verify_firmware_artifacts.py",
+        "firmware/artifacts.json",
         "releases/package_firmware.py",
     }
 )
 IDF_SHARED_PREFIXES = ("config/", "examples/esp-idf/components/", "components/")
 ARDUINO_LIBRARY_PREFIX = "examples/arduino/libraries/"
 FIRMWARE_PREFIX = "firmware/"
-RELEASE_ARTIFACT_SUFFIXES = {".bin", ".zip", ".7z", ".rar", ".tar", ".tgz", ".gz", ".bz2", ".xz"}
+DELIVERY_ARCHIVE_SUFFIXES = {".zip", ".7z", ".rar", ".tar", ".tgz", ".gz", ".bz2", ".xz"}
 
 
 def normalize(path: str) -> str:
@@ -83,6 +86,72 @@ def _owned(path: str, entries: list[dict[str, str]]) -> str | None:
     return None
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        result[key] = value
+    return result
+
+
+def delivery_archives(repo: Path) -> set[str]:
+    """Return explicitly declared delivery archives; malformed manifests declare none."""
+    try:
+        data = json.loads(
+            (repo / "firmware/artifacts.json").read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
+        if (
+            not isinstance(data, dict)
+            or set(data) != {"version", "artifacts"}
+            or type(data["version"]) is not int
+            or data["version"] != 1
+            or not isinstance(data["artifacts"], list)
+        ):
+            return set()
+        artifacts = data["artifacts"]
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError):
+        return set()
+    paths = set()
+    for artifact in artifacts:
+        if (
+            not isinstance(artifact, dict)
+            or set(artifact) != {"path", "kind", "sha256", "size"}
+        ):
+            return set()
+        path = artifact.get("path")
+        kind = artifact.get("kind")
+        digest = artifact.get("sha256")
+        size = artifact.get("size")
+        if (
+            not isinstance(path, str)
+            or not path
+            or "\\" in path
+            or kind not in {"firmware", "delivery_archive"}
+            or not isinstance(digest, str)
+            or len(digest) != 64
+            or any(char not in "0123456789abcdef" for char in digest)
+            or isinstance(size, bool)
+            or not isinstance(size, int)
+            or size < 0
+        ):
+            return set()
+        candidate = PurePosixPath(path)
+        if candidate.is_absolute() or any(
+            part in {"", ".", ".."} for part in candidate.parts
+        ):
+            return set()
+        suffix = Path(path).suffix.lower()
+        if kind == "firmware" and suffix != ".bin":
+            return set()
+        if kind == "delivery_archive":
+            if suffix not in DELIVERY_ARCHIVE_SUFFIXES:
+                return set()
+            paths.add(candidate.as_posix())
+    return paths
+
+
 @dataclass
 class Route:
     idf: set[str] = field(default_factory=set)
@@ -116,19 +185,26 @@ class Route:
 def classify(paths: list[str], repo: Path) -> Route:
     idf_entries = discover_examples.discover_esp_idf(repo)
     arduino_entries = discover_examples.discover_arduino(repo)
+    declared_archives = delivery_archives(repo)
     route = Route()
     for path in paths:
+        if path in GLOBAL_PATHS:
+            route.non_document = True
+            route.all_idf = route.all_arduino = True
+            if path == "firmware/artifacts.json":
+                route.firmware_touched = True
+                route.release_review_required = True
+            continue
         if path.startswith(FIRMWARE_PREFIX):
             route.firmware_touched = True
-            route.release_review_required |= Path(path).suffix.lower() in RELEASE_ARTIFACT_SUFFIXES
+            route.release_review_required |= (
+                Path(path).suffix.lower() == ".bin" or path in declared_archives
+            )
             route.non_document |= not is_document(path)
             continue
         if is_document(path) or is_docs_asset(path) or is_governance(path):
             continue
         route.non_document = True
-        if path in GLOBAL_PATHS:
-            route.all_idf = route.all_arduino = True
-            continue
         if path.startswith(IDF_SHARED_PREFIXES):
             route.all_idf = True
             continue
@@ -147,7 +223,7 @@ def classify(paths: list[str], repo: Path) -> Route:
         # build input, so ownership rules above take precedence. Unowned
         # checked-in artifacts are a release-review surface, not a reason to
         # compile unrelated product examples.
-        if Path(path).suffix.lower() in RELEASE_ARTIFACT_SUFFIXES:
+        if Path(path).suffix.lower() == ".bin" or path in declared_archives:
             route.release_review_required = True
             continue
         route.all_idf = route.all_arduino = True

--- a/scripts/verify_firmware_artifacts.py
+++ b/scripts/verify_firmware_artifacts.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Verify immutable, checked-in firmware artifacts without modifying them."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+
+
+MANIFEST_VERSION = 1
+SHA256_LENGTH = 64
+DELIVERY_ARCHIVE_SUFFIXES = frozenset(
+    {".zip", ".7z", ".rar", ".tar", ".tgz", ".gz", ".bz2", ".xz"}
+)
+
+
+class VerificationError(ValueError):
+    """The manifest or an immutable artifact is invalid."""
+
+
+def safe_relative_path(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise VerificationError("artifact path must be a non-empty string")
+    if "\\" in value:
+        raise VerificationError(f"artifact path must use POSIX separators: {value}")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise VerificationError(f"unsafe artifact path: {value}")
+    return path.as_posix()
+
+
+def index_entries(repo: Path) -> dict[str, tuple[str, str]]:
+    result = subprocess.run(
+        ["git", "-C", str(repo), "ls-files", "-s", "-z"],
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode:
+        raise VerificationError("cannot read checked-in files with git ls-files")
+    entries: dict[str, tuple[str, str]] = {}
+    for item in result.stdout.split(b"\0"):
+        if not item:
+            continue
+        metadata, path = item.split(b"\t", 1)
+        mode, object_id, stage = metadata.decode("ascii").split()
+        if stage != "0":
+            continue
+        entries[path.decode("utf-8")] = (mode, object_id)
+    return entries
+
+
+def index_blob(repo: Path, object_id: str) -> bytes:
+    result = subprocess.run(
+        ["git", "-C", str(repo), "cat-file", "blob", object_id],
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode:
+        raise VerificationError("cannot read artifact from the Git index")
+    return result.stdout
+
+
+def reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise VerificationError(f"duplicate JSON object key: {key}")
+        result[key] = value
+    return result
+
+
+def read_manifest(contents: bytes) -> list[dict[str, object]]:
+    try:
+        data = json.loads(contents.decode("utf-8"), object_pairs_hook=reject_duplicate_keys)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise VerificationError(f"cannot read manifest: {error}") from error
+    if not isinstance(data, dict) or set(data) != {"version", "artifacts"}:
+        raise VerificationError("manifest schema must contain only version and artifacts")
+    if (
+        type(data["version"]) is not int
+        or data["version"] != MANIFEST_VERSION
+        or not isinstance(data["artifacts"], list)
+    ):
+        raise VerificationError("unsupported manifest version or artifacts list")
+
+    artifacts: list[dict[str, object]] = []
+    seen_paths: set[str] = set()
+    for item in data["artifacts"]:
+        if not isinstance(item, dict) or set(item) != {"path", "kind", "sha256", "size"}:
+            raise VerificationError("artifact schema must contain path, kind, sha256, and size")
+        path = safe_relative_path(item["path"])
+        kind = item["kind"]
+        digest = item["sha256"]
+        size = item["size"]
+        if path in seen_paths:
+            raise VerificationError(f"duplicate artifact path: {path}")
+        seen_paths.add(path)
+        if kind not in {"firmware", "delivery_archive"}:
+            raise VerificationError(f"unsupported artifact kind: {kind}")
+        if kind == "firmware" and Path(path).suffix.lower() != ".bin":
+            raise VerificationError(f"firmware artifact must end in .bin: {path}")
+        if kind == "delivery_archive" and Path(path).suffix.lower() not in DELIVERY_ARCHIVE_SUFFIXES:
+            raise VerificationError(f"delivery archive has an unsupported suffix: {path}")
+        if not isinstance(digest, str) or len(digest) != SHA256_LENGTH or any(
+            char not in "0123456789abcdef" for char in digest
+        ):
+            raise VerificationError(f"invalid SHA-256 digest: {path}")
+        if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+            raise VerificationError(f"invalid artifact size: {path}")
+        artifacts.append({"path": path, "kind": kind, "sha256": digest, "size": size})
+    return artifacts
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def verify(repo: Path, manifest: Path, index: bool = False) -> None:
+    repo = repo.resolve()
+    try:
+        manifest_relative = safe_relative_path(manifest.absolute().relative_to(repo).as_posix())
+    except ValueError as error:
+        raise VerificationError("manifest must be inside the repository") from error
+    entries = index_entries(repo)
+    manifest_entry = entries.get(manifest_relative)
+    if index:
+        if manifest_entry is None:
+            raise VerificationError("manifest is not checked in")
+        if manifest_entry[0] != "100644":
+            raise VerificationError("manifest must be a regular index entry")
+        manifest_contents = index_blob(repo, manifest_entry[1])
+    else:
+        if manifest.is_symlink():
+            raise VerificationError("manifest must not be a symlink")
+        if manifest_entry is not None and manifest_entry[0] != "100644":
+            raise VerificationError("manifest must be a regular index entry")
+        try:
+            manifest_contents = manifest.read_bytes()
+        except OSError as error:
+            raise VerificationError(f"cannot read manifest: {error}") from error
+    artifacts = read_manifest(manifest_contents)
+    listed_paths = {artifact["path"] for artifact in artifacts}
+
+    for artifact in artifacts:
+        path = artifact["path"]
+        file_path = repo / path
+        try:
+            file_path.resolve().relative_to(repo)
+        except ValueError as error:
+            raise VerificationError(f"artifact resolves outside the repository: {path}") from error
+        entry = entries.get(path)
+        if entry is None:
+            raise VerificationError(f"artifact is not checked in: {path}")
+        if entry[0] == "120000" or (not index and file_path.is_symlink()):
+            raise VerificationError(f"artifact must not be a symlink: {path}")
+        if entry[0] != "100644":
+            raise VerificationError(f"artifact must be a regular index entry: {path}")
+        if index:
+            contents = index_blob(repo, entry[1])
+            if len(contents) != artifact["size"]:
+                raise VerificationError(f"size mismatch: {path}")
+            if hashlib.sha256(contents).hexdigest() != artifact["sha256"]:
+                raise VerificationError(f"SHA-256 mismatch: {path}")
+            continue
+        if not file_path.is_file():
+            raise VerificationError(f"missing artifact: {path}")
+        if file_path.stat().st_size != artifact["size"]:
+            raise VerificationError(f"size mismatch: {path}")
+        if sha256_file(file_path) != artifact["sha256"]:
+            raise VerificationError(f"SHA-256 mismatch: {path}")
+
+    unlisted_artifacts = sorted(
+        path
+        for path in entries
+        if Path(path).suffix.lower() == ".bin" and path not in listed_paths
+    )
+    if unlisted_artifacts:
+        raise VerificationError(
+            f"unlisted checked-in firmware binary: {', '.join(unlisted_artifacts)}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", default=".")
+    parser.add_argument("--manifest", default="firmware/artifacts.json")
+    parser.add_argument("--index", action="store_true", help="verify Git index blobs")
+    args = parser.parse_args()
+    repo = Path(args.repo)
+    manifest = Path(args.manifest)
+    if not manifest.is_absolute():
+        manifest = repo / manifest
+    try:
+        verify(repo, manifest, args.index)
+    except VerificationError as error:
+        print(f"firmware-artifacts: {error}", file=sys.stderr)
+        raise SystemExit(1)
+    print("firmware artifacts verified")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_repository_tools.py
+++ b/tests/test_repository_tools.py
@@ -31,12 +31,22 @@ package_firmware = load_module("package_firmware", "releases/package_firmware.py
 download_artifacts = load_module(
     "download_artifacts_impl", "releases/download_artifacts_impl.py"
 )
+firmware_artifacts = load_module(
+    "verify_firmware_artifacts", "scripts/verify_firmware_artifacts.py"
+)
 
 
 def write_file(root: Path, relative_path: str, content: str = "") -> Path:
     path = root / relative_path
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
+    return path
+
+
+def write_bytes(root: Path, relative_path: str, content: bytes) -> Path:
+    path = root / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
     return path
 
 
@@ -135,6 +145,32 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(discover.DEFAULT_IDF_VERSIONS, "v5.5.5,v6.0.2")
         self.assertEqual(discover.DEFAULT_ARDUINO_CORE, "3.3.11")
 
+    def test_documented_full_matrix_counts_match_real_discovery(self) -> None:
+        idf_projects = discover.discover_esp_idf(REPO_ROOT)
+        arduino_sketches = discover.discover_arduino(REPO_ROOT)
+        idf_builds = len(idf_projects) * len(discover.DEFAULT_IDF_VERSIONS.split(","))
+        total_builds = idf_builds + len(arduino_sketches)
+
+        self.assertEqual((len(idf_projects), idf_builds, len(arduino_sketches), total_builds), (10, 20, 13, 33))
+        self.assertEqual(
+            [entry["name"] for entry in arduino_sketches],
+            [
+                "01_HelloWorld", "02_AsciiTable", "03_Drawing_points",
+                "05_GFX_PCF85063_simpleTime", "06_GFX_ESPWiFiAnalyzer",
+                "07_GFX_Clock", "08_LVGL_PCF85063_simpleTime",
+                "09_LVGL_Widgets", "10_LVGL_SD", "11_TWAItransmit",
+                "12_TWAIreceive", "13_RS485", "14_LVGL_BatteryVoltage",
+            ],
+        )
+        for relative_path, expected in (
+            ("README.md", f"with at most {total_builds} firmware build jobs"),
+            ("README_CN.md", f"最多 {total_builds} 个固件构建任务"),
+            ("docs/CI.md", f"largest matrix is {total_builds} builds ({len(idf_projects)} ESP-IDF examples × 2 versions plus {len(arduino_sketches)} Arduino sketches)"),
+            ("docs/CI_CN.md", f"完整矩阵最多 {total_builds} 个构建（{len(idf_projects)} 个 ESP-IDF 示例 × 2 个版本，加 {len(arduino_sketches)} 个 Arduino sketches）"),
+        ):
+            with self.subTest(path=relative_path):
+                self.assertIn(expected, (REPO_ROOT / relative_path).read_text(encoding="utf-8"))
+
 
 class WorkflowContractTests(unittest.TestCase):
     def test_example_workflow_enforces_selection_and_versions(self) -> None:
@@ -199,6 +235,22 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("actions/upload-artifact@v6", examples_workflow)
         self.assertNotIn("actions/upload-artifact@v4", examples_workflow)
         self.assertIn("arduino/setup-arduino-cli@v2", examples_workflow)
+
+    def test_repository_tools_workflow_verifies_immutable_firmware(self) -> None:
+        workflow = (REPO_ROOT / ".github/workflows/repository-tools.yml").read_text(
+            encoding="utf-8"
+        )
+        verifier = (
+            "python3 scripts/verify_firmware_artifacts.py --repo . "
+            "--manifest firmware/artifacts.json --index"
+        )
+        tests = 'python3 -m unittest discover -s tests -p "test_*.py" -v'
+        self.assertIn("push: {}", workflow)
+        self.assertIn("pull_request: {}", workflow)
+        self.assertNotIn("paths:", workflow)
+        self.assertNotIn("branches:", workflow)
+        self.assertIn(verifier, workflow)
+        self.assertLess(workflow.index(verifier), workflow.index(tests))
 
     def test_markdown_audit_scope_control_flow_handles_all_events(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/examples.yml").read_text(
@@ -277,18 +329,41 @@ class RoutingTests(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertEqual(self.counts(self.outputs(f"M\t{path}\n")), (0, 0))
 
-    def test_document_assets_and_release_archives_skip_example_builds(self) -> None:
+    def test_document_assets_and_explicit_release_archives_are_routed(self) -> None:
         asset = self.outputs("M\tdocs/diagram.png\n")
         self.assertEqual(self.counts(asset), (0, 0))
         self.assertEqual(asset["docs_only"], "true")
         family_asset = self.outputs("M\tassets/ESP32-S3-LCD-4-family.jpg\n")
         self.assertEqual(self.counts(family_asset), (0, 0))
         self.assertEqual(family_asset["docs_only"], "true")
-        archive = self.outputs("M\treleases/delivery.zip\n")
-        self.assertEqual(self.counts(archive), (0, 0))
-        self.assertEqual(archive["release_review_required"], "true")
-        self.assertEqual(archive["firmware_touched"], "false")
-        self.assertIn("release review required", archive["route_summary"])
+
+        unclassified = self.outputs("M\treleases/delivery.zip\n")
+        self.assertEqual(self.counts(unclassified), (4, 2))
+        self.assertEqual(unclassified["release_review_required"], "false")
+        self.assertIn("unknown paths", unclassified["route_summary"])
+
+        write_file(
+            self.repo,
+            "firmware/artifacts.json",
+            json.dumps(
+                {
+                    "version": 1,
+                    "artifacts": [
+                        {
+                            "path": "releases/delivery.zip",
+                            "kind": "delivery_archive",
+                            "sha256": "0" * 64,
+                            "size": 0,
+                        }
+                    ],
+                }
+            ),
+        )
+        classified = self.outputs("M\treleases/delivery.zip\n")
+        self.assertEqual(self.counts(classified), (0, 0))
+        self.assertEqual(classified["release_review_required"], "true")
+        self.assertEqual(classified["firmware_touched"], "false")
+        self.assertIn("release review required", classified["route_summary"])
 
         owned_archive = self.outputs(
             "M\texamples/esp-idf/Alpha/main/runtime-assets.zip\n"
@@ -302,6 +377,21 @@ class RoutingTests(unittest.TestCase):
         workflow = self.outputs("M\t.github/workflows/examples.yml\n")
         self.assertEqual(self.counts(workflow), (4, 2))
         self.assertNotIn("unknown paths", workflow["route_summary"])
+        for path in (
+            ".github/workflows/repository-tools.yml",
+            "scripts/verify_firmware_artifacts.py",
+        ):
+            with self.subTest(path=path):
+                output = self.outputs(f"M\t{path}\n")
+                self.assertEqual(self.counts(output), (4, 2))
+                self.assertNotIn("unknown paths", output["route_summary"])
+                self.assertEqual(output["firmware_touched"], "false")
+                self.assertEqual(output["release_review_required"], "false")
+        manifest = self.outputs("M\tfirmware/artifacts.json\n")
+        self.assertEqual(self.counts(manifest), (4, 2))
+        self.assertEqual(manifest["firmware_touched"], "true")
+        self.assertEqual(manifest["release_review_required"], "true")
+        self.assertNotIn("unknown paths", manifest["route_summary"])
         self.assertEqual(
             route_ci.normalize("./.github/workflows/examples.yml/"),
             ".github/workflows/examples.yml",
@@ -315,7 +405,7 @@ class RoutingTests(unittest.TestCase):
             self.assertEqual(output["firmware_touched"], "true")
             self.assertEqual(
                 output["release_review_required"],
-                str(path.endswith((".bin", ".zip"))).lower(),
+                str(path.endswith(".bin")).lower(),
             )
 
     def test_rename_and_delete_include_old_paths(self) -> None:
@@ -339,6 +429,173 @@ class RoutingTests(unittest.TestCase):
             check=False,
         )
         self.assertEqual(result.returncode, 2)
+
+
+class FirmwareArtifactTests(unittest.TestCase):
+    artifact_path = "firmware/factory.bin"
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temp_dir.name)
+        subprocess.run(["git", "init", "-q", str(self.repo)], check=True)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def manifest(self, artifacts: list[dict[str, object]] | None = None) -> Path:
+        data = b"factory-image"
+        write_bytes(self.repo, self.artifact_path, data)
+        artifact = {
+            "path": self.artifact_path,
+            "kind": "firmware",
+            "sha256": firmware_artifacts.sha256_file(self.repo / self.artifact_path),
+            "size": len(data),
+        }
+        manifest = write_file(
+            self.repo,
+            "firmware/artifacts.json",
+            json.dumps({"version": 1, "artifacts": artifacts if artifacts is not None else [artifact]}),
+        )
+        subprocess.run(["git", "-C", str(self.repo), "add", "-A"], check=True)
+        return manifest
+
+    def test_verify_passes_for_a_checked_in_artifact(self) -> None:
+        firmware_artifacts.verify(self.repo, self.manifest())
+
+    def test_verify_rejects_hash_and_size_mismatches(self) -> None:
+        manifest = self.manifest()
+        write_bytes(self.repo, self.artifact_path, b"changed-image")
+        with self.assertRaisesRegex(firmware_artifacts.VerificationError, "SHA-256 mismatch"):
+            firmware_artifacts.verify(self.repo, manifest)
+        write_bytes(self.repo, self.artifact_path, b"changed")
+        with self.assertRaisesRegex(firmware_artifacts.VerificationError, "size mismatch"):
+            firmware_artifacts.verify(self.repo, manifest)
+
+    def test_verify_rejects_invalid_manifest_schema(self) -> None:
+        manifest = self.manifest()
+        manifest.write_text('{"version": 1, "artifacts": [], "extra": true}', encoding="utf-8")
+        with self.assertRaisesRegex(firmware_artifacts.VerificationError, "manifest schema"):
+            firmware_artifacts.verify(self.repo, manifest)
+
+    def test_verify_rejects_duplicate_json_keys_and_boolean_version(self) -> None:
+        manifest = self.manifest()
+        manifest.write_text(
+            '{"version": 1, "version": 1, "artifacts": []}',
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(
+            firmware_artifacts.VerificationError, "duplicate JSON object key"
+        ):
+            firmware_artifacts.verify(self.repo, manifest)
+
+        manifest.write_text(
+            '{"version": true, "artifacts": []}', encoding="utf-8"
+        )
+        with self.assertRaisesRegex(
+            firmware_artifacts.VerificationError, "unsupported manifest version"
+        ):
+            firmware_artifacts.verify(self.repo, manifest)
+
+    def test_verify_rejects_missing_artifacts(self) -> None:
+        manifest = self.manifest()
+        (self.repo / self.artifact_path).unlink()
+        with self.assertRaisesRegex(firmware_artifacts.VerificationError, "missing artifact"):
+            firmware_artifacts.verify(self.repo, manifest)
+
+    def test_verify_rejects_unsafe_and_duplicate_paths(self) -> None:
+        unsafe = self.manifest(
+            [{"path": "../outside.bin", "kind": "firmware", "sha256": "0" * 64, "size": 0}]
+        )
+        with self.assertRaisesRegex(firmware_artifacts.VerificationError, "unsafe artifact path"):
+            firmware_artifacts.verify(self.repo, unsafe)
+
+        duplicate = self.manifest(
+            [
+                {"path": self.artifact_path, "kind": "firmware", "sha256": "0" * 64, "size": 0},
+                {"path": self.artifact_path, "kind": "firmware", "sha256": "0" * 64, "size": 0},
+            ]
+        )
+        with self.assertRaisesRegex(firmware_artifacts.VerificationError, "duplicate artifact path"):
+            firmware_artifacts.verify(self.repo, duplicate)
+
+    def test_verify_rejects_an_unlisted_checked_in_binary(self) -> None:
+        manifest = self.manifest()
+        write_bytes(self.repo, "firmware/unlisted.bin", b"unlisted")
+        subprocess.run(["git", "-C", str(self.repo), "add", "firmware/unlisted.bin"], check=True)
+        with self.assertRaisesRegex(firmware_artifacts.VerificationError, "unlisted checked-in firmware binary"):
+            firmware_artifacts.verify(self.repo, manifest)
+
+    def test_verify_does_not_infer_an_unclassified_checked_in_archive(self) -> None:
+        manifest = self.manifest()
+        write_bytes(self.repo, "firmware/unlisted.zip", b"unlisted")
+        subprocess.run(["git", "-C", str(self.repo), "add", "firmware/unlisted.zip"], check=True)
+        firmware_artifacts.verify(self.repo, manifest)
+
+    def test_verify_passes_for_a_listed_delivery_archive(self) -> None:
+        archive_path = "firmware/delivery.zip"
+        data = b"delivery-archive"
+        archive = write_bytes(self.repo, archive_path, data)
+        manifest = write_file(
+            self.repo,
+            "firmware/artifacts.json",
+            json.dumps(
+                {
+                    "version": 1,
+                    "artifacts": [{
+                        "path": archive_path,
+                        "kind": "delivery_archive",
+                        "sha256": firmware_artifacts.sha256_file(archive),
+                        "size": len(data),
+                    }],
+                }
+            ),
+        )
+        subprocess.run(["git", "-C", str(self.repo), "add", "-A"], check=True)
+        firmware_artifacts.verify(self.repo, manifest)
+
+    def test_verify_rejects_a_listed_symlink_artifact(self) -> None:
+        manifest = self.manifest()
+        artifact = self.repo / self.artifact_path
+        target = write_bytes(self.repo, "firmware/target.dat", artifact.read_bytes())
+        artifact.unlink()
+        try:
+            artifact.symlink_to(target.name)
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"symlinks are unavailable: {error}")
+        subprocess.run(["git", "-C", str(self.repo), "add", "-A"], check=True)
+        with self.assertRaisesRegex(firmware_artifacts.VerificationError, "artifact must not be a symlink"):
+            firmware_artifacts.verify(self.repo, manifest)
+        with self.assertRaisesRegex(firmware_artifacts.VerificationError, "artifact must not be a symlink"):
+            firmware_artifacts.verify(self.repo, manifest, index=True)
+
+    def test_index_verification_uses_staged_blobs(self) -> None:
+        manifest = self.manifest()
+        write_bytes(self.repo, self.artifact_path, b"changed-after-staging")
+        with self.assertRaisesRegex(
+            firmware_artifacts.VerificationError, "size mismatch"
+        ):
+            firmware_artifacts.verify(self.repo, manifest)
+        firmware_artifacts.verify(self.repo, manifest, index=True)
+
+    def test_untracked_manifest_is_allowed_only_in_worktree_mode(self) -> None:
+        manifest = self.manifest()
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(self.repo),
+                "rm",
+                "--cached",
+                "firmware/artifacts.json",
+            ],
+            check=True,
+            capture_output=True,
+        )
+        firmware_artifacts.verify(self.repo, manifest)
+        with self.assertRaisesRegex(
+            firmware_artifacts.VerificationError, "manifest is not checked in"
+        ):
+            firmware_artifacts.verify(self.repo, manifest, index=True)
 
 
 class ReleaseHelperTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add a checked-in immutable firmware inventory with strict path, type, size, and SHA-256 verification
- verify exact Git index blobs in the always-on repository-tools workflow
- route integrity-policy changes through the complete ESP-IDF and Arduino matrices while keeping factory binaries outside example builds
- require explicit manifest evidence before treating archives as delivery artifacts
- document managed-component pin policy and firmware boundaries in English and Simplified Chinese
- expand discovery, routing, workflow, and artifact-integrity regression coverage

## Static validation

- `python3 scripts/verify_firmware_artifacts.py --repo . --manifest firmware/artifacts.json --index`
- `python3 -m unittest discover -s tests -p 'test_*.py' -v` — 72 tests passed
- repository and reusable Markdown audits with `config/markdown-audit.json` — 0 errors
- routing cases cover global integrity inputs, factory binaries, documentation, and unknown archives
- inventory confirms 10 ESP-IDF projects across v5.5.5/v6.0.2 and 13 Arduino sketches on core 3.3.11

## GitHub Actions

Validated at head `6c46e9000b392713b80011b8452c9af12b9795ad`:

- [Test Repository Tools](https://github.com/waveshareteam/ESP32-S3-Touch-LCD-4/actions/runs/31694082805) — success
- [Build Examples](https://github.com/waveshareteam/ESP32-S3-Touch-LCD-4/actions/runs/31694082985) — 35/35 jobs succeeded
  - 20 ESP-IDF builds: 10 projects across v5.5.5 and v6.0.2
  - 13 Arduino builds on core 3.3.11
  - routing and final `ci-status` gates succeeded

Product firmware builds were delegated exclusively to GitHub Actions for this pull-request head.

## Immutable artifacts

The existing factory binary remains unchanged at 2,913,440 bytes with SHA-256 `5db7ee79f1063465d8114cea3a4675c8c87bdf303c2a3edaf6a55414c8634706`.